### PR TITLE
Fix for iPuz coloring

### DIFF
--- a/js/crosswords.js
+++ b/js/crosswords.js
@@ -32,6 +32,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
       color_hilite: '#fff5d7',
       color_none: '#FFFFFF',
       background_color_clue: '#666666',
+      default_background_color: '#c2ed7e',
       font_color_clue: '#FFFFFF',
       color_block: '#000000',
       puzzle_file: null,
@@ -555,6 +556,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             right: c['right-bar'] === true,
           };
           c.color = c['background-color'];
+          // if they tried to define a color but did it badly, use the default
+          if (c.color && !c.color.match('^#[A-Za-z0-9]{6}$')) {
+            c.color = this.default_background_color;
+            c['background-color'] = this.default_background_color;
+          }
           c.shape = c['background-shape'];
           this.cells[c.x][c.y] = c;
 

--- a/lib/jscrossword/jscrossword_combined.js
+++ b/lib/jscrossword/jscrossword_combined.js
@@ -37,7 +37,8 @@ function xw_read_ipuz(data) {
         'description': data.intro || '',
         'height': height,
         'width': width,
-        'crossword_type': crossword_type
+        'crossword_type': crossword_type,
+        'fakeclues': data.fakeclues
     };
 
     /*
@@ -104,6 +105,11 @@ function xw_read_ipuz(data) {
             // background shape and color
             background_shape = style.shapebg;
             background_color = style.color;
+            // official iPuz style is RGB without a "#"
+            // we add that if it's missing
+            if (background_color && background_color.match('^[A-Fa-f0-9]{6}$')) {
+              background_color = '#' + background_color.toString();
+            }
             // top-right numbers
             var top_right_number = null;
             if (style.mark) {


### PR DESCRIPTION
Also define a default color, following squares.io's lead